### PR TITLE
Create ECR repository with Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,11 @@ build/
 
 # IntelliJ Idea
 .idea
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+

--- a/terraform/README.MD
+++ b/terraform/README.MD
@@ -1,0 +1,18 @@
+Install aws-vault
+
+`brew cask install aws-vault`
+
+This means we can support our preferred security configuration of having MFA enabled for IAM user
+accounts. See [this GitHub issue for more context as to why aws-vault is needed](https://github.com/terraform-providers/terraform-provider-aws/issues/2420).
+
+Configure your AWS CLI install as per [the Identity Access Management Confluence page](https://dsdmoj.atlassian.net/wiki/spaces/LM/pages/293536178/Identity+Access+Management).
+
+`aws-vault add laa-shared-services`
+
+This configures aws-vault to contain the details needed to interact with terraform (namely MFA session management).
+ 
+Then you should be able to run terraform, similar to:
+
+`aws-vault exec laa-shared-services-lz -- terraform plan`
+
+You might be prompted for your MFA token, but the plan should be created.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  backend "s3" {
+    bucket               = "laa-digital-terraform-state"
+    region               = "eu-west-2"
+    key                  = "ccmsdeploymentspike.tfstate"
+    workspace_key_prefix = "laa-platform"
+    profile              = "laa-shared-services"
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_ecr_repository" "ccms_deployment_spike" {
+  name = "laa-ccms-deployment-spike"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,3 @@
+variable "region" {
+  default = "eu-west-2"
+}


### PR DESCRIPTION
We need an ERC repository to store our docker image, and we want to use
terraform to do this.

We still need to create a circle CI user and role, policy etc but this
is the first step and proves we can create resources with terraform.