### PR TITLE
Push Docker image to the ECR repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,18 @@ version: 2.1
 orbs:
   gradle: circleci/gradle@1.0.11
   docker: circleci/docker@0.5.13
+  deployment-spike:
+    commands:
+      ecr_login:
+        steps:
+          - run:
+              name: Login to ECR
+              command: |
+                temp_role=$(aws sts assume-role --role-arn arn:aws:iam::902837325998:role/CircleCi --role-session-name ci)
+                export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+                export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+                export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+                eval $(aws ecr get-login --no-include-email --region=eu-west-2)
 
 workflows:
   checkout-build-test:
@@ -41,4 +53,11 @@ jobs:
           name: Copy build artifacts from workspace
           command: cp -r /tmp/workspace/project/build /home/circleci/project/
       - docker/build:
-          image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+          image: 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike
+          tag: latest
+      - deployment-spike/ecr_login
+      - run:
+          name: Push container
+          command: |
+            docker push 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike
+


### PR DESCRIPTION
Previously we created an ECR repository for the spike at 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike using terraform.

We also set up a CircleCI user which has permission to push to this repository. This user is intended to be shared across the whole LAA account. This is not in CloudFormation/Terraform yet, but when we do this for real we would need to add it to https://github.com/ministryofjustice/laa-aws-infrastructure

The changes in this PR are to add a step which pushes the docker image to the ECR repository, so we can deploy it. First we login as CircleCi using an access key, then we push to the ECR repository within the laa-shared-services account.

This is based on the OPG deployment pipelines, for example https://github.com/ministryofjustice/opg-use-an-lpa/blob/master/.circleci/config.yml