### PR TITLE
Run terraform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,14 @@ orbs:
 workflows:
   checkout-build-test:
     jobs:
-      - lint_and_apply_terraform
+      - validate_and_plan_terraform
+      - approve_terraform:
+          type: approval
+          requires:
+            - validate_and_plan_terraform
+      - apply_terraform:
+          requires:
+            - approve_terraform
       - gradle/test:
           test_results_path: build/reports/tests
           reports_path: build/reports/
@@ -27,7 +34,7 @@ workflows:
       - build_docker_image:
           requires:
             - build_jar
-            - lint_and_apply_terraform
+            - validate_and_plan_terraform
 
 jobs:
   build_jar:
@@ -64,19 +71,28 @@ jobs:
             docker push 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike
 
 
-  lint_and_apply_terraform:
-    #
-    # Lint the Terraform
-    #
+  validate_and_plan_terraform:
     docker:
       - image: hashicorp/terraform
     steps:
       - checkout
       - run:
-          name: Lint Terraform
+          name: Validate and plan terraform
           command: |
             terraform --version
             cd ~/project/terraform/
             terraform init -lock-timeout=300s
             terraform validate
             terraform plan
+
+  apply_terraform:
+      docker:
+        - image: hashicorp/terraform
+      steps:
+        - checkout
+        - run:
+            name: Apply terraform
+            command: |
+              cd ~/project/terraform/
+              terraform init -lock-timeout=300s
+              terraform apply -lock-timeout=300s --auto-approve

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ orbs:
 workflows:
   checkout-build-test:
     jobs:
+      - lint_and_apply_terraform
       - gradle/test:
           test_results_path: build/reports/tests
           reports_path: build/reports/
@@ -26,6 +27,7 @@ workflows:
       - build_docker_image:
           requires:
             - build_jar
+            - lint_and_apply_terraform
 
 jobs:
   build_jar:
@@ -77,3 +79,4 @@ jobs:
             cd ~/project/terraform/
             terraform init -lock-timeout=300s
             terraform validate
+            terraform plan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,3 +61,19 @@ jobs:
           command: |
             docker push 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike
 
+
+  lint_and_apply_terraform:
+    #
+    # Lint the Terraform
+    #
+    docker:
+      - image: hashicorp/terraform
+    steps:
+      - checkout
+      - run:
+          name: Lint Terraform
+          command: |
+            terraform --version
+            cd ~/project/terraform/
+            terraform init -lock-timeout=300s
+            terraform validate

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,14 +4,28 @@ terraform {
     region               = "eu-west-2"
     key                  = "ccmsdeploymentspike.tfstate"
     workspace_key_prefix = "laa-platform"
-    profile              = "laa-shared-services"
+    role_arn             = "arn:aws:iam::902837325998:role/CircleCi"
   }
 }
 
 provider "aws" {
   region = var.region
+
+  assume_role {
+    role_arn     = "arn:aws:iam::411213865113:role/Terraform"
+  }
+}
+
+provider "aws" {
+  region = var.region
+  alias  = "shared-services"
+
+  assume_role {
+    role_arn     = "arn:aws:iam::902837325998:role/TerraformRole"
+  }
 }
 
 resource "aws_ecr_repository" "ccms_deployment_spike" {
   name = "laa-ccms-deployment-spike"
+  provider = aws.shared-services
 }


### PR DESCRIPTION
First validate the terraform and come up with a plan.
Then we have a manual approval step. We added this in because we are still building out the terraform and we want to make sure it's correct before running anything.
After that, apply the terraform using the circleci user.

The circleci user assumes a Terraform role in order to run the terraform. There is a different one for each of the AWS accounts. The ECR repository lives in the shared-services account but the infrastructure the app will run on will live in an environment specific account.