### PR TITLE
Create an ECS cluster with terraform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ workflows:
       - build_docker_image:
           requires:
             - build_jar
-            - validate_and_plan_terraform
+            - apply_terraform
 
 jobs:
   build_jar:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,16 @@ orbs:
 workflows:
   checkout-build-test:
     jobs:
-      - validate_and_plan_terraform
+#      - validate_and_plan_terraform
+      - plan_destroy_terraform
       - approve_terraform:
           type: approval
           requires:
-            - validate_and_plan_terraform
-      - apply_terraform:
+            - plan_destroy_terraform
+#      - apply_terraform:
+#          requires:
+#            - approve_terraform
+      - destroy_terraform:
           requires:
             - approve_terraform
       - gradle/test:
@@ -34,7 +38,7 @@ workflows:
       - build_docker_image:
           requires:
             - build_jar
-            - validate_and_plan_terraform
+#            - validate_and_plan_terraform
 
 jobs:
   build_jar:
@@ -96,3 +100,29 @@ jobs:
               cd ~/project/terraform/
               terraform init -lock-timeout=300s
               terraform apply -lock-timeout=300s --auto-approve
+
+
+  plan_destroy_terraform:
+    docker:
+      - image: hashicorp/terraform
+    steps:
+      - checkout
+      - run:
+          name: Validate and plan terraform
+          command: |
+            terraform --version
+            cd ~/project/terraform/
+            terraform init -lock-timeout=300s
+            terraform plan -destroy
+
+  destroy_terraform:
+    docker:
+      - image: hashicorp/terraform
+    steps:
+      - checkout
+      - run:
+          name: Delete terraform
+          command: |
+            cd ~/project/terraform/
+            terraform init -lock-timeout=300s
+            terraform destroy --auto-approve

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,16 +19,12 @@ orbs:
 workflows:
   checkout-build-test:
     jobs:
-#      - validate_and_plan_terraform
-      - plan_destroy_terraform
+      - validate_and_plan_terraform
       - approve_terraform:
           type: approval
           requires:
-            - plan_destroy_terraform
-#      - apply_terraform:
-#          requires:
-#            - approve_terraform
-      - destroy_terraform:
+            - validate_and_plan_terraform
+      - apply_terraform:
           requires:
             - approve_terraform
       - gradle/test:
@@ -38,7 +34,7 @@ workflows:
       - build_docker_image:
           requires:
             - build_jar
-#            - validate_and_plan_terraform
+            - validate_and_plan_terraform
 
 jobs:
   build_jar:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,3 +29,12 @@ resource "aws_ecr_repository" "ccms_deployment_spike" {
   name = "laa-ccms-deployment-spike"
   provider = aws.shared-services
 }
+
+module "cluster" {
+  source = "./modules/app-cluster"
+  region = var.region
+  providers = { # Assumes the role in the development account
+    aws = "aws"
+  }
+  app_image = "${aws_ecr_repository.ccms_deployment_spike.repository_url}:latest"
+}

--- a/terraform/modules/app-cluster/README.md
+++ b/terraform/modules/app-cluster/README.md
@@ -1,0 +1,11 @@
+# Application cluster
+
+This module sets up an ECS Fargate cluster to run the docker containers.
+
+## Inputs
+
+TODO
+
+## Outputs
+
+TODO

--- a/terraform/modules/app-cluster/logs.tf
+++ b/terraform/modules/app-cluster/logs.tf
@@ -1,0 +1,7 @@
+# Set up CloudWatch group and log stream and retain logs for 30 days
+resource "aws_cloudwatch_log_group" "hello_world_log_group" {
+  name              = "hello-world-ecs"
+  retention_in_days = 3
+
+  //tags = local.default_tags
+}

--- a/terraform/modules/app-cluster/logs.tf
+++ b/terraform/modules/app-cluster/logs.tf
@@ -5,3 +5,8 @@ resource "aws_cloudwatch_log_group" "hello_world_log_group" {
 
   //tags = local.default_tags
 }
+
+resource "aws_cloudwatch_log_stream" "hello_world_log_stream" {
+  name           = "hello-world-log-stream"
+  log_group_name = aws_cloudwatch_log_group.hello_world_log_group.name
+}

--- a/terraform/modules/app-cluster/main.tf
+++ b/terraform/modules/app-cluster/main.tf
@@ -50,6 +50,9 @@ resource "aws_ecs_service" "main" {
   launch_type     = "FARGATE"
 
   network_configuration {
+    security_groups = [
+      aws_security_group.ecs_tasks.id,
+    ]
     subnets = [
       data.aws_cloudformation_stack.landing_zone.outputs["AppPrivateSubnetA"],
       data.aws_cloudformation_stack.landing_zone.outputs["AppPrivateSubnetB"],

--- a/terraform/modules/app-cluster/main.tf
+++ b/terraform/modules/app-cluster/main.tf
@@ -1,0 +1,66 @@
+resource "aws_ecs_cluster" "main" {
+  name = "hello-world-cluster"
+}
+
+data "template_file" "hello_world_app" {
+  template = file("${path.module}/templates/hello_world.json.tpl")
+
+  vars = {
+    service         = local.service
+    app_image       = var.app_image
+    app_port        = var.app_port
+    fargate_cpu     = var.fargate_cpu
+    fargate_memory  = var.fargate_memory
+    aws_region      = var.region
+    management_port = var.management_port
+  }
+}
+
+// Need this to get subnet things
+data "aws_cloudformation_stack" "landing_zone" {
+  name = "LAA-${var.environment}"
+}
+
+// Need this to get Route53 things that we can add our new name to
+data "aws_cloudformation_stack" "dns" {
+  name = "LAA-dns-${var.environment}"
+}
+
+# This is the blueprint for our app
+resource "aws_ecs_task_definition" "app" {
+  family             = "hello-world-task"
+  execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
+  network_mode       = "awsvpc"
+  requires_compatibilities = [
+    "FARGATE",
+  ]
+  cpu                   = var.fargate_cpu
+  memory                = var.fargate_memory
+  container_definitions = data.template_file.hello_world_app.rendered
+
+//  tags = local.default_tags
+}
+
+# This ensures we have the required number of containers running
+resource "aws_ecs_service" "main" {
+  name            = "hello-world"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = var.app_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets = [
+      data.aws_cloudformation_stack.landing_zone.outputs["AppPrivateSubnetA"],
+      data.aws_cloudformation_stack.landing_zone.outputs["AppPrivateSubnetB"],
+      data.aws_cloudformation_stack.landing_zone.outputs["AppPrivateSubnetC"],
+    ]
+    assign_public_ip = true
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.ecs_task_execution_role,
+  ]
+
+  //tags = local.default_tags
+}

--- a/terraform/modules/app-cluster/roles.tf
+++ b/terraform/modules/app-cluster/roles.tf
@@ -1,0 +1,31 @@
+# ECS task execution role data
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
+data "aws_iam_policy_document" "ecs_task_execution_role" {
+  version = "2012-10-17"
+  statement {
+    sid    = ""
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "ecs-tasks.amazonaws.com",
+      ]
+    }
+  }
+}
+
+# ECS task execution role
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = var.ecs_task_execution_role_name
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+}
+
+# ECS task execution role policy attachment
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}

--- a/terraform/modules/app-cluster/security.tf
+++ b/terraform/modules/app-cluster/security.tf
@@ -1,0 +1,65 @@
+# ALB Security Group: Edit to restrict access to the application
+resource "aws_security_group" "lb" {
+  name        = "hello-world-api-load-balancer-security-group"
+  description = "controls access to the ALB"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    protocol  = "tcp"
+    from_port = 443
+    to_port   = 443
+    cidr_blocks = [
+      // TODO: ingress should only be from MOJ Cloud Platform and MOJ Internal IP addresses?
+      "0.0.0.0/0",
+    ]
+  }
+
+  egress {
+    protocol  = "-1"
+    from_port = 0
+    to_port   = 0
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+
+  //tags = local.default_tags
+}
+
+# Traffic to the ECS cluster should only come from the ALB
+resource "aws_security_group" "ecs_tasks" {
+  name        = "hello-world-ecs-tasks-security-group"
+  description = "allow inbound access from the ALB only"
+  vpc_id      = var.vpc_id
+
+  // Allow application traffic to hit the Docker containers
+  ingress {
+    protocol  = "tcp"
+    from_port = var.app_port
+    to_port   = var.app_port
+    security_groups = [
+      aws_security_group.lb.id,
+    ]
+  }
+
+  // Allow the ALB healthchecks to hit the Docker container management interface
+  ingress {
+    protocol  = "tcp"
+    from_port = var.management_port
+    to_port   = var.management_port
+    security_groups = [
+      aws_security_group.lb.id,
+    ]
+  }
+
+  egress {
+    protocol  = "-1"
+    from_port = 0
+    to_port   = 0
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+
+  //tags = local.default_tags
+}

--- a/terraform/modules/app-cluster/security.tf
+++ b/terraform/modules/app-cluster/security.tf
@@ -61,5 +61,15 @@ resource "aws_security_group" "ecs_tasks" {
     ]
   }
 
+  // Allow access from the workspace whilst we don't have an ALB
+    ingress {
+    protocol  = "tcp"
+    from_port = var.app_port
+    to_port   = var.app_port
+    cidr_blocks = [
+      "10.200.0.0/20",
+    ]
+  }
+
   //tags = local.default_tags
 }

--- a/terraform/modules/app-cluster/templates/hello_world.json.tpl
+++ b/terraform/modules/app-cluster/templates/hello_world.json.tpl
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "${service}",
+    "image": "${app_image}",
+    "cpu": ${fargate_cpu},
+    "memory": ${fargate_memory},
+    "networkMode": "awsvpc",
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "hello-world-ecs",
+          "awslogs-region": "${aws_region}",
+          "awslogs-stream-prefix": "ecs"
+        }
+    },
+    "portMappings": [
+      {
+        "containerPort": ${app_port},
+        "hostPort": ${app_port}
+      },
+      {
+        "containerPort": ${management_port},
+        "hostPort": ${management_port}
+      }
+    ]
+  }
+]

--- a/terraform/modules/app-cluster/variables.tf
+++ b/terraform/modules/app-cluster/variables.tf
@@ -1,0 +1,73 @@
+variable "region" {
+  default = "eu-west-2"
+}
+
+variable "environment" {
+  description = "environment/account"
+  default     = "development"
+}
+
+variable "ecs_task_execution_role_name" {
+  description = "ECS task execution role name"
+  default     = "providerDetailsTaskExecutionRole"
+}
+
+variable "ecs_auto_scale_role_name" {
+  description = "ECS auto scale role Name"
+  default     = "providerDetailsAutoScaleRole"
+}
+
+variable "az_count" {
+  description = "Number of AZs to cover in a given region"
+  default     = "2"
+}
+
+variable "app_image" {
+  description = "Docker image to run in the ECS cluster"
+  default     = "902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike:latest"
+}
+
+variable "app_port" {
+  description = "Port exposed by the docker image to redirect traffic to"
+  default     = 8080
+}
+
+variable "management_port" {
+  description = "Port exposed by the docker image for the management interface"
+  default     = 8081
+}
+
+variable "app_count" {
+  description = "Number of docker containers to run"
+  default     = 1
+}
+
+variable "health_check_path" {
+  default = "/actuator/health"
+}
+
+// See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
+variable "fargate_cpu" {
+  description = "Fargate instance CPU units to provision (1 vCPU = 1024 CPU units)"
+  default     = "256"
+}
+
+variable "fargate_memory" {
+  description = "Fargate instance memory to provision (in MiB)"
+  default     = "512"
+}
+
+locals {
+  service = "hello-world"
+
+  default_tags = {
+    business-unit = "LAA"
+    application   = "Deployment Pipeline Hello World"
+    // TODO: this should vary per environment
+    environment-name       = "development"
+    owner                  = "laa-role-sre@digital.justice.gov.uk"
+    infrastructure-support = "LAA WebOps: laa-role-sre@digital.justice.gov.uk"
+    // TODO: this should vary per environment
+    is-production = "false"
+  }
+}

--- a/terraform/modules/app-cluster/variables.tf
+++ b/terraform/modules/app-cluster/variables.tf
@@ -57,6 +57,12 @@ variable "fargate_memory" {
   default     = "512"
 }
 
+variable "vpc_id" {
+  description = "VPC ID - will need to vary per environment/account"
+  default     = "vpc-86e0dfef"
+  // development
+}
+
 locals {
   service = "hello-world"
 


### PR DESCRIPTION
We added some terraform to create an ECS cluster and run a task in it. This is based on a spike Jabley did [here](https://github.com/ministryofjustice/laa-ccms-provider-details-api/compare/feature/aws-infrastructure).