### PR TITLE
Update pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,14 +19,6 @@ orbs:
 workflows:
   checkout-build-test:
     jobs:
-      - validate_and_plan_terraform
-      - approve_terraform:
-          type: approval
-          requires:
-            - validate_and_plan_terraform
-      - apply_terraform:
-          requires:
-            - approve_terraform
       - gradle/test:
           test_results_path: build/reports/tests
           reports_path: build/reports/
@@ -36,7 +28,16 @@ workflows:
       - build_docker_image:
           requires:
             - build_jar
-            - apply_terraform
+      - validate_and_plan_terraform:
+          requires:
+            - build_docker_image
+      - approve_terraform:
+          type: approval
+          requires:
+            - validate_and_plan_terraform
+      - apply_terraform:
+          requires:
+            - approve_terraform
 
 jobs:
   build_jar:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,10 @@ workflows:
       - build_docker_image:
           requires:
             - build_jar
+      - ignore_ecr_repo
       - validate_and_plan_terraform:
           requires:
+            - ignore_ecr_repo
             - build_docker_image
       - approve_terraform:
           type: approval
@@ -125,3 +127,14 @@ jobs:
             cd ~/project/terraform/
             terraform init -lock-timeout=300s
             terraform destroy --auto-approve
+
+  ignore_ecr_repo:
+    docker:
+      - image: hashicorp/terraform
+    steps:
+      - checkout
+      - run:
+          command: |
+            cd ~/project/terraform/
+            terraform init -lock-timeout=300s
+            terraform state rm 'aws_ecr_repository.ccms_deployment_spike'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,10 +25,11 @@ provider "aws" {
   }
 }
 
-resource "aws_ecr_repository" "ccms_deployment_spike" {
-  name = "laa-ccms-deployment-spike"
-  provider = aws.shared-services
-}
+// This should go in the laa-aws-infrastructure repository
+//resource "aws_ecr_repository" "ccms_deployment_spike" {
+//  name = "laa-ccms-deployment-spike"
+//  provider = aws.shared-services
+//}
 
 module "cluster" {
   source = "./modules/app-cluster"
@@ -36,5 +37,4 @@ module "cluster" {
   providers = { # Assumes the role in the development account
     aws = "aws"
   }
-  app_image = "${aws_ecr_repository.ccms_deployment_spike.repository_url}:latest"
 }


### PR DESCRIPTION
Reorder the pipeline so we create the docker image before creating the ECS cluster/tasks.

Remove the ECR from this terraform - we think it should be managed separately from the application infrastructure so that if we tear down all the infrastructure we still have all the images we've built. We intend to move this to laa-aws-infrastructure.