### PR TITLE
Add dns

### DIFF
--- a/terraform/development.tfvars
+++ b/terraform/development.tfvars
@@ -1,3 +1,4 @@
 environment_terraform_role = "arn:aws:iam::411213865113:role/Terraform"
 vpc_id = "vpc-86e0dfef"
 certificate_arn = "arn:aws:acm:eu-west-2:411213865113:certificate/0184743f-c424-4d2e-bd87-f2ac439c38ad"
+environment_dns = "hello-world.dev.legalservices.gov.uk"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,4 +44,5 @@ module "cluster" {
   }
   vpc_id = var.vpc_id
   certificate_arn = var.certificate_arn
+  environment_dns = var.environment_dns
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,6 +25,11 @@ provider "aws" {
   }
 }
 
+// Need this to get Route53 things that we can add our new name to
+data "aws_cloudformation_stack" "dns" {
+  name = "LAA-dns-${terraform.workspace}"
+}
+
 // This should go in the laa-aws-infrastructure repository
 //resource "aws_ecr_repository" "ccms_deployment_spike" {
 //  name = "laa-ccms-deployment-spike"

--- a/terraform/modules/app-cluster/dns.tf
+++ b/terraform/modules/app-cluster/dns.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "ccms_provider_details" {
+  zone_id = data.aws_cloudformation_stack.dns.outputs["HostedZoneId"]
+  name    = "hello-world.dev.legalservices.gov.uk"
+  type = "A"
+
+  alias {
+    name                   = aws_alb.main.dns_name
+    zone_id                = aws_alb.main.zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/modules/app-cluster/dns.tf
+++ b/terraform/modules/app-cluster/dns.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "ccms_provider_details" {
   zone_id = data.aws_cloudformation_stack.dns.outputs["HostedZoneId"]
-  name    = "hello-world.dev.legalservices.gov.uk"
+  name    = var.environment_dns
   type = "A"
 
   alias {

--- a/terraform/modules/app-cluster/variables.tf
+++ b/terraform/modules/app-cluster/variables.tf
@@ -61,6 +61,10 @@ variable "certificate_arn" {
   description = "The certificate for the ALB Listener"
 }
 
+variable "environment_dns" {
+  description = "The root that the user will access the application from"
+}
+
 locals {
   service = "hello-world"
 

--- a/terraform/test.tfvars
+++ b/terraform/test.tfvars
@@ -1,3 +1,4 @@
 environment_terraform_role = "arn:aws:iam::013163512034:role/CircleCi"
 vpc_id="vpc-feac9397"
 certificate_arn = "arn:aws:acm:eu-west-2:013163512034:certificate/3f5ffd24-0805-475a-80ad-8bc0f1330e83"
+environment_dns = "hello-world.tst.legalservices.gov.uk"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,3 +14,7 @@ variable "certificate_arn" {
   description = "The certificate for the ALB Listener"
 }
 
+variable "environment_dns" {
+  description = "The root that the user will access the application from"
+}
+


### PR DESCRIPTION
Add an AWS route53 record. We create 2 URLs, https://hello-world.dev.legalservices.gov.uk/ and https://hello-world.tst.legalservices.gov.uk/ for the dev and test environments.