### PR TITLE
Fix health check path

### DIFF
--- a/terraform/modules/app-cluster/load_balancer.tf
+++ b/terraform/modules/app-cluster/load_balancer.tf
@@ -26,7 +26,6 @@ resource "aws_alb_target_group" "app" {
     matcher             = "200"
     timeout             = "3"
     path                = var.health_check_path
-    port                = var.management_port
     unhealthy_threshold = "2"
   }
 

--- a/terraform/modules/app-cluster/variables.tf
+++ b/terraform/modules/app-cluster/variables.tf
@@ -38,7 +38,7 @@ variable "app_count" {
 }
 
 variable "health_check_path" {
-  default = "/actuator/health"
+  default = "/"
 }
 
 // See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html


### PR DESCRIPTION
Health check path was set to /actuator/health which is an invalid path,
this was causing the target group health checks to fail, so ECS
continually started and shutdown instances.

This changes it to a path of / and removes the health check port (this
will default to the traffic port)

linted-by: git-pre-commit-lint.sh v1.8.4

```
Binaries required for validation:
	tflint:		OK      ✔

Checked files:
	terraform/modules/app-cluster/
```