### PR TITLE
Add container version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,7 @@ orbs:
                 cd ~/project/terraform/
                 terraform init
                 terraform validate
-                terraform plan -var-file=$TF_WORKSPACE.tfvars
-              # -var container_version=$CIRCLE_BRANCH-$SHORT_HASH
+                terraform plan -var-file=$TF_WORKSPACE.tfvars -var container_version=$SHORT_HASH
       apply_terraform:
         #
         # Apply the environment terraform configuration. This:
@@ -61,8 +60,7 @@ orbs:
                 export SHORT_HASH=${CIRCLE_SHA1:0:7} >> $BASH_ENV
                 cd ~/project/terraform/
                 terraform init
-                terraform apply -var-file=$TF_WORKSPACE.tfvars --auto-approve
-              # -var container_version=$CIRCLE_BRANCH-$SHORT_HASH
+                terraform apply -var-file=$TF_WORKSPACE.tfvars --auto-approve -var container_version=$SHORT_HASH
 
 workflows:
   checkout-build-test:
@@ -137,8 +135,15 @@ jobs:
       - run:
           name: Push container
           command: |
-            docker push 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike
+            export SHORT_HASH=${CIRCLE_SHA1:0:7} >> $BASH_ENV
+            docker tag 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike:latest 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike:$SHORT_HASH
 
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              # We want all of the tags pushed
+              docker push 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike
+            else
+              docker push 902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike:$SHORT_HASH
+            fi
 
   # Not used
   plan_destroy_terraform:

--- a/src/main/java/hello/HelloController.java
+++ b/src/main/java/hello/HelloController.java
@@ -8,7 +8,7 @@ public class HelloController {
 
   @RequestMapping("/")
   public String index() {
-    return "Greetings from Spring Boot!";
+    return "Greetings from Spring Boot! - Make a change";
   }
 
 }

--- a/src/test/java/hello/HelloControllerTest.java
+++ b/src/test/java/hello/HelloControllerTest.java
@@ -26,6 +26,6 @@ public class HelloControllerTest {
   public void getHello() throws Exception {
     mvc.perform(MockMvcRequestBuilders.get("/").accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(content().string(equalTo("Greetings from Spring Boot!")));
+        .andExpect(content().string(equalTo("Greetings from Spring Boot! - Make a change")));
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,4 +45,5 @@ module "cluster" {
   vpc_id = var.vpc_id
   certificate_arn = var.certificate_arn
   environment_dns = var.environment_dns
+  container_version = var.container_version
 }

--- a/terraform/modules/app-cluster/main.tf
+++ b/terraform/modules/app-cluster/main.tf
@@ -6,13 +6,14 @@ data "template_file" "hello_world_app" {
   template = file("${path.module}/templates/hello_world.json.tpl")
 
   vars = {
-    service         = local.service
-    app_image       = var.app_image
-    app_port        = var.app_port
-    fargate_cpu     = var.fargate_cpu
-    fargate_memory  = var.fargate_memory
-    aws_region      = var.region
-    management_port = var.management_port
+    service           = local.service
+    app_image         = var.app_image
+    app_port          = var.app_port
+    fargate_cpu       = var.fargate_cpu
+    fargate_memory    = var.fargate_memory
+    aws_region        = var.region
+    management_port   = var.management_port
+    container_version = var.container_version
   }
 }
 

--- a/terraform/modules/app-cluster/templates/hello_world.json.tpl
+++ b/terraform/modules/app-cluster/templates/hello_world.json.tpl
@@ -1,7 +1,7 @@
 [
   {
     "name": "${service}",
-    "image": "${app_image}",
+    "image": "${app_image}:${container_version}",
     "cpu": ${fargate_cpu},
     "memory": ${fargate_memory},
     "networkMode": "awsvpc",

--- a/terraform/modules/app-cluster/variables.tf
+++ b/terraform/modules/app-cluster/variables.tf
@@ -19,7 +19,7 @@ variable "az_count" {
 
 variable "app_image" {
   description = "Docker image to run in the ECS cluster"
-  default     = "902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike:latest"
+  default     = "902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-ccms-deployment-spike"
 }
 
 variable "app_port" {
@@ -63,6 +63,10 @@ variable "certificate_arn" {
 
 variable "environment_dns" {
   description = "The root that the user will access the application from"
+}
+
+variable "container_version" {
+  default = "latest"
 }
 
 locals {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,3 +18,6 @@ variable "environment_dns" {
   description = "The root that the user will access the application from"
 }
 
+variable "container_version" {
+  default = "latest"
+}


### PR DESCRIPTION
When we make a change to the spring boot app, the tast definition is not
updated, and the new image is not deployed.
Currently we always use the "latest" image version, because of
this Terraform does not detect any changes to the task definition.  By
using the version rather than the latest, if there is a change it should
be detected.

This change adds back in the container version, used in a similar way to
OPG.

linted-by: git-pre-commit-lint.sh v1.8.4

```
Binaries required for validation:
	yamllint:	OK      ✔
	tflint:		OK      ✔

Checked files:
	.circleci/config.yml
	terraform/modules/app-cluster/
	terraform/

Unchecked or partially validated files:
	terraform/modules/app-cluster/templates/hello_world.json.tpl
```

linted-by: git-pre-commit-lint.sh v1.8.4

```
Binaries required for validation:
	yamllint:	OK      ✔
	tflint:		OK      ✔

Checked files:
	.circleci/config.yml
	terraform/modules/app-cluster/
```

linted-by: git-pre-commit-lint.sh v1.8.4

```
Binaries required for validation:
	yamllint:	OK      ✔

Checked files:
	.circleci/config.yml
```

linted-by: git-pre-commit-lint.sh v1.8.4

```

Unchecked or partially validated files:
	terraform/modules/app-cluster/templates/hello_world.json.tpl
```

linted-by: git-pre-commit-lint.sh v1.8.4

```
Binaries required for validation:
	yamllint:	OK      ✔

Checked files:
	.circleci/config.yml
```

linted-by: git-pre-commit-lint.sh v1.8.4

```

Unchecked or partially validated files:
	src/main/java/hello/HelloController.java
	src/test/java/hello/HelloControllerTest.java
```

linted-by: git-pre-commit-lint.sh v1.8.4

```
Binaries required for validation:
	tflint:		OK      ✔

Checked files:
	terraform/
```

linted-by: git-pre-commit-lint.sh v1.8.4

```
Binaries required for validation:
	yamllint:	OK      ✔

Checked files:
	.circleci/config.yml
```